### PR TITLE
Upgrade `git-spawned-stream` dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - 'stable'
-  - '0.12'
-  - '0.10'
+  - lts/dubnium
+  - node
 sudo: false
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Shelling out to git-diff-tree(1) in a Node streamy fashion",
   "main": "index.js",
   "dependencies": {
-    "git-spawned-stream": "~0.1.0",
+    "git-spawned-stream": "^1.0.1",
     "pump-chain": "^1.0.0",
     "split-transform-stream": "~0.1.1",
     "through2": "~2.0.0"


### PR DESCRIPTION
git-spawned-stream before v1.0.0 had security vulnerabilities (see https://github.com/alessioalex/git-spawned-stream/commit/434b0acf4e48a6a5422cea6ff479b2670630b458). This PR bumps it to use the version where these have been fixed.

Context: I'm investigating some security vulnerabilities in my project and encountered this. I'd appreciate if this were addressed to unblock my own fixing of security vulnerabilities!

I didn't bump the package version since I wasn't sure if this would warrant a major or minor revision 👍